### PR TITLE
[feat]create toast to deal with errors

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from 'next/font/google';
 import './globals.css';
 import { ClerkProvider } from '@clerk/nextjs';
 import { ModalProvider } from '@/providers/modal-provider';
+import { ToasterProvider } from '@/providers/toast-provider';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -20,6 +21,7 @@ export default function RootLayout ({
     <ClerkProvider>
       <html lang="en">
         <body className={inter.className}>
+          <ToasterProvider />
           <ModalProvider />
           {children}
         </body>

--- a/components/modals/store-modal.tsx
+++ b/components/modals/store-modal.tsx
@@ -8,6 +8,7 @@ import * as z from 'zod';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form';
 import { Input } from '../ui/input';
 import { Button } from '../ui/button';
+import toast from 'react-hot-toast';
 
 const formSchema = z.object({
   name: z.string().min(1),
@@ -33,7 +34,7 @@ export const StoreModal = () => {
       const result = await response.json();
       console.log(result);
     } catch (error) {
-      console.log('error', error);
+      toast.error('Something went wrong. Please try again.');
     } finally {
       form.reset();
     }

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -14,6 +14,25 @@ describe('Home', () => {
       .then(() => cy.contains("[type='submit']").should('be.disabled'))
   });
 
+  it('should show error if request fail', async () => {
+    cy.intercept('POST', '/api/store', {
+      statusCode: 500,
+    }).as('store');
+    
+    cy.visit('/', {
+      headers: {
+        'Cookie': '__client_uat=0'
+      }
+    });
+    cy.contains('Create store')
+    cy.get('#dialog-close').click()
+    cy.contains('Create store')
+    cy.get('input').type('Test Store')
+    cy.get("[type='submit']").click()
+    cy.wait('@store')
+    cy.contains('Something went wrong. Please try again.')
+  });
+
   it('should show error message if store name is empty', () => {
     cy.visit('/', {
       headers: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.51.3",
+        "react-hot-toast": "^2.4.1",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.0",
@@ -4228,8 +4229,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cypress": {
       "version": "13.8.0",
@@ -6202,6 +6202,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.14.tgz",
+      "integrity": "sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -9583,6 +9591,21 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.51.3",
+    "react-hot-toast": "^2.4.1",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.0",

--- a/providers/toast-provider.tsx
+++ b/providers/toast-provider.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { Toaster } from 'react-hot-toast';
+
+export const ToasterProvider = () => {
+  return <Toaster />
+};
+


### PR DESCRIPTION
This pull request primarily introduces a new toast notification feature to the application. The changes include the addition of a new `ToasterProvider`, the integration of `react-hot-toast` library, and the modification of error handling in the `StoreModal` component. Additionally, an end-to-end test has been added to verify the error toast notification.

New feature introduction:

* [`app/layout.tsx`](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR6): Imported the `ToasterProvider` and added it to the application's layout. 
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R28): Added the `react-hot-toast` library to the project's dependencies.
* [`providers/toast-provider.tsx`](diffhunk://#diff-e28ec5a2e0f851b1bd93a71b7d8d36765721515c059863838783a4557d65779fR1-R8): Created a new `ToasterProvider` component that wraps the `Toaster` component from `react-hot-toast`.

Error handling modification:

* [`components/modals/store-modal.tsx`](diffhunk://#diff-c2255b2afe1537b2767e0c77031f82d14c3b07ba36bc3b05f6bb15ec30578acdR11): Imported `toast` from `react-hot-toast` and replaced the console log error message with a toast error notification. 

Testing:

* [`cypress/e2e/home.cy.ts`](diffhunk://#diff-d137d2c5c0d9fcafd8b0d62d005db915aee25a072c101f8992ded547b899b614R17-R35): Added an end-to-end test to verify that an error toast notification is displayed when a request to `/api/store` fails.